### PR TITLE
fix: prevents verdier from being valid when there is a chouette

### DIFF
--- a/domain/rules/level-3/verdier-rule.spec.ts
+++ b/domain/rules/level-3/verdier-rule.spec.ts
@@ -1,6 +1,7 @@
 import { Resolver } from "../rule-resolver";
 import { DummyContextBuilder } from "../../tests/dummy-game-context-builder";
 import {
+  isVerdierApplicable,
   VerdierResolution,
   VerdierResolutionPayload,
   VerdierRule,
@@ -8,7 +9,6 @@ import {
 import { RuleEffect, RuleEffectEvent } from "../rule-effect";
 import { ChouetteRule } from "../basic-rules/chouette-rule";
 import { RuleRunner } from "../../rule-runner";
-import { VeluteRule } from "../basic-rules/velute-rule";
 
 describe("isApplicableToGameContext", () => {
   let dummyResolver: Resolver<VerdierResolution, VerdierResolutionPayload>;
@@ -38,7 +38,7 @@ describe("isApplicableToGameContext", () => {
 });
 
 describe("applyRule", () => {
-  it("applies the dice roll rule effets to the player", async () => {
+  it("applies the dice roll rule effects to the player", async () => {
     const resolver: Resolver<VerdierResolution, VerdierResolutionPayload> = {
       getResolution: jest.fn().mockResolvedValue({
         bettingPlayerNames: [],
@@ -121,5 +121,31 @@ describe("applyRule", () => {
       playerName: "Delphin",
       score: -5,
     });
+  });
+});
+
+describe("isVerdierApplicable", () => {
+  it("returns false when given 0-0-0", () => {
+    const result = isVerdierApplicable([0, 0, 0]);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when given 0-0-5", () => {
+    const result = isVerdierApplicable([0, 0, 5]);
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when given 4-0-2", () => {
+    const result = isVerdierApplicable([4, 0, 2]);
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when given 2-2-0", () => {
+    const result = isVerdierApplicable([0, 2, 2]);
+
+    expect(result).toBe(false);
   });
 });

--- a/domain/rules/level-3/verdier-rule.ts
+++ b/domain/rules/level-3/verdier-rule.ts
@@ -76,13 +76,15 @@ export class VerdierRule implements Rule {
 }
 
 export function isVerdierApplicable(diceForm: DiceForm): boolean {
-  const numberOfValidDieValue = diceForm.reduce((acc: number, dieFormValue) => {
-    if (dieFormValue === 2 || dieFormValue === 4 || dieFormValue === 6) {
-      return acc + 1;
-    }
+  const invalidValues = diceForm.filter((dieValue) => {
+    return dieValue === 1 || dieValue === 3 || dieValue === 5;
+  });
 
-    return acc;
-  }, 0);
+  if (invalidValues.length > 0) {
+    return false;
+  }
 
-  return numberOfValidDieValue > 1;
+  const [d1, d2, d3] = diceForm;
+
+  return d1 !== d2 && d1 !== d3 && d2 !== d3;
 }

--- a/src/views/current-game-history/CurrentGameHistory.vue
+++ b/src/views/current-game-history/CurrentGameHistory.vue
@@ -7,7 +7,9 @@
 
       <v-col>
         <router-link :to="scribePanelRoutePath">
-          <v-btn x-large>Revenir à la partie en cours</v-btn>
+          <v-btn tile color="grey darken-3" dark>
+            Revenir à la partie en cours
+          </v-btn>
         </router-link>
       </v-col>
 

--- a/src/views/scribe-panel/ScribePanel.vue
+++ b/src/views/scribe-panel/ScribePanel.vue
@@ -9,7 +9,7 @@
       </v-col>
       <v-col>
         <router-link :to="currentGameHistoryRoutePath">
-          <v-btn tile>
+          <v-btn tile color="grey darken-3" dark>
             <v-icon class="mr-2" small>mdi-table-large</v-icon>
             Afficher l'historique
           </v-btn>


### PR DESCRIPTION
Le verdier était mal codé, certaines combinaisons de dés étaient faussement valides.
Comme par exemple:
2 2 x
4 4 x